### PR TITLE
Implement win/loss tracking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import './App.css'
 import { getOrCreatePlayer } from './playerManager'
 import DealerHand from './components/DealerHand'
@@ -6,7 +6,9 @@ import PlayerHand from './components/PlayerHand'
 import Message from './components/Message'
 import Controls from './components/Controls'
 import Leaderboard from './components/Leaderboard'
+import Scoreboard from './components/Scoreboard'
 import { startGame, hit, dealerTurn } from './game/blackjackLogic'
+import { supabase } from './supabaseClient'
 
 function App() {
   const [playerId, setPlayerId] = useState(null)
@@ -14,11 +16,18 @@ function App() {
   const [dealerHand, setDealerHand] = useState([])
   const [gameState, setGameState] = useState('player_turn')
   const [deck, setDeck] = useState([])
+  const [wins, setWins] = useState(0)
+  const [losses, setLosses] = useState(0)
+  const [streak, setStreak] = useState(0)
+  const prevGameState = useRef(null)
 
   useEffect(() => {
     async function init() {
       const player = await getOrCreatePlayer()
       setPlayerId(player.id)
+      setWins(player.win_count ?? 0)
+      setLosses(player.loss_count ?? 0)
+      setStreak(player.streak ?? 0)
 
       const { deck, playerHand, dealerHand, result } = startGame();
       setDeck(deck);
@@ -71,9 +80,45 @@ function App() {
     }
   }, [gameState, deck, dealerHand, playerHand]);
 
+  useEffect(() => {
+    async function updateStats() {
+      if (!playerId) return;
+      if (prevGameState.current === gameState) return;
+
+      prevGameState.current = gameState;
+
+      if (['player_busts', 'dealer_wins'].includes(gameState)) {
+        const newLosses = losses + 1;
+        const { data, error } = await supabase
+          .from('blackjack_players')
+          .update({ loss_count: newLosses })
+          .eq('id', playerId)
+          .select('loss_count')
+          .single();
+        if (!error && data) {
+          setLosses(data.loss_count);
+        }
+      } else if (['player_wins', 'dealer_busts'].includes(gameState)) {
+        const newWins = wins + 1;
+        const { data, error } = await supabase
+          .from('blackjack_players')
+          .update({ win_count: newWins })
+          .eq('id', playerId)
+          .select('win_count')
+          .single();
+        if (!error && data) {
+          setWins(data.win_count);
+        }
+      }
+    }
+
+    updateStats();
+  }, [gameState, playerId, losses, wins]);
+
   return (
     <div className="App relative">
       <Leaderboard />
+      <Scoreboard wins={wins} losses={losses} streak={streak} />
       <Message gameState={gameState} />
       <PlayerHand hand={playerHand} />
       <Controls onHit={handleHit} onStand={handleStand} gameState={gameState} />

--- a/src/components/Scoreboard.jsx
+++ b/src/components/Scoreboard.jsx
@@ -1,0 +1,14 @@
+function Scoreboard({ wins, losses, streak }) {
+    return (
+        <div
+            className="fixed top-12 right-12 z-[9999] bg-black/60 rounded-xl border border-black shadow-lg text-white text-md md:text-lg lg:text-xl xl:text-2xl 2xl:text-3xl px-3 py-1 lg:px-4 lg:py-2 xl:px-5 xl:py-3 2xl:px-6 2xl:py-4"
+        >
+            <p>Wins: {wins}</p>
+            <p>Losses: {losses}</p>
+            <p>Streak: {streak}</p>
+        </div>
+    )
+}
+
+export default Scoreboard
+


### PR DESCRIPTION
## Summary
- add a simple Scoreboard component to display user stats
- track wins and losses via Supabase
- show win/loss/streak data in the UI
- ensure win/loss counters update only once per game result
- make scoreboard responsive like other UI elements

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847817b1a2c832593f418a53d3be6a0