### PR TITLE
Add settings modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Message from './components/Message'
 import Controls from './components/Controls'
 import Leaderboard from './components/Leaderboard'
 import Scoreboard from './components/Scoreboard'
+import Settings from './components/Settings'
 import { startGame, hit, dealerTurn } from './game/blackjackLogic'
 import { supabase } from './supabaseClient'
 
@@ -19,6 +20,10 @@ function App() {
   const [wins, setWins] = useState(0)
   const [losses, setLosses] = useState(0)
   const [streak, setStreak] = useState(0)
+  const [username, setUsername] = useState('')
+  const [scoreboardVisible, setScoreboardVisible] = useState(true)
+  const [controlsVisible, setControlsVisible] = useState(true)
+  const [settingsOpen, setSettingsOpen] = useState(false)
 
   useEffect(() => {
     async function init() {
@@ -27,6 +32,7 @@ function App() {
       setWins(player.win_count ?? 0)
       setLosses(player.loss_count ?? 0)
       setStreak(player.streak ?? 0)
+      setUsername(player.username)
 
       const { deck, playerHand, dealerHand, result } = startGame();
       setDeck(deck);
@@ -49,6 +55,16 @@ function App() {
 
   function handleStand() {
     setGameState('dealer_turn');
+  }
+
+  const handleUsernameUpdated = (name) => {
+    setUsername(name)
+  }
+
+  const handleStatsResetState = () => {
+    setWins(0)
+    setLosses(0)
+    setStreak(0)
   }
 
   const startNewRound = () => {
@@ -113,12 +129,34 @@ function App() {
 
   return (
     <div className="App relative">
+      <button
+        className="fixed top-4 right-4 text-2xl"
+        onClick={() => setSettingsOpen(true)}
+      >
+        ⚙️
+      </button>
       <Leaderboard />
-      <Scoreboard wins={wins} losses={losses} streak={streak} />
+      {scoreboardVisible && (
+        <Scoreboard wins={wins} losses={losses} streak={streak} />
+      )}
       <Message gameState={gameState} />
       <PlayerHand hand={playerHand} />
-      <Controls onHit={handleHit} onStand={handleStand} gameState={gameState} />
+      {controlsVisible && (
+        <Controls onHit={handleHit} onStand={handleStand} gameState={gameState} />
+      )}
       <DealerHand hand={dealerHand} gameState={gameState} />
+      <Settings
+        isOpen={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        playerId={playerId}
+        currentUsername={username}
+        onUsernameChange={handleUsernameUpdated}
+        scoreboardVisible={scoreboardVisible}
+        setScoreboardVisible={setScoreboardVisible}
+        controlsVisible={controlsVisible}
+        setControlsVisible={setControlsVisible}
+        onStatsReset={handleStatsResetState}
+      />
     </div>
   )
 }

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,0 +1,133 @@
+import { useState, useEffect } from 'react'
+import Modal from './Modal'
+import { supabase } from '../supabaseClient'
+
+function Settings({
+    isOpen,
+    onClose,
+    playerId,
+    currentUsername,
+    onUsernameChange,
+    scoreboardVisible,
+    setScoreboardVisible,
+    controlsVisible,
+    setControlsVisible,
+    onStatsReset
+}) {
+    const [username, setUsername] = useState(currentUsername || '')
+    const [error, setError] = useState('')
+
+    useEffect(() => {
+        setUsername(currentUsername || '')
+    }, [currentUsername])
+
+    const handleUsernameChange = async () => {
+        setError('')
+        if (username.length < 3 || username.length > 12) {
+            setError('Username must be 3-12 characters.')
+            setUsername(currentUsername)
+            return
+        }
+        try {
+            const profanityRes = await fetch(
+                `https://www.purgomalum.com/service/containsprofanity?text=${encodeURIComponent(username)}`
+            )
+            const profanity = await profanityRes.text()
+            if (profanity === 'true') {
+                setError('Username contains profanity.')
+                setUsername(currentUsername)
+                return
+            }
+        } catch (e) {
+            console.error('Profanity check failed', e)
+        }
+
+        const { data: existing, error: dbErr } = await supabase
+            .from('blackjack_players')
+            .select('id')
+            .ilike('username', username)
+            .neq('id', playerId)
+
+        if (!dbErr && existing && existing.length > 0) {
+            setError('Username already taken.')
+            setUsername(currentUsername)
+            return
+        }
+
+        const { data, error: updateErr } = await supabase
+            .from('blackjack_players')
+            .update({ username })
+            .eq('id', playerId)
+            .select('username')
+            .single()
+
+        if (!updateErr && data) {
+            onUsernameChange(data.username)
+        } else {
+            setError('Failed to update username.')
+            setUsername(currentUsername)
+        }
+    }
+
+    const handleResetStats = async () => {
+        const { error } = await supabase
+            .from('blackjack_players')
+            .update({ win_count: 0, loss_count: 0, streak: 0 })
+            .eq('id', playerId)
+        if (!error) {
+            onStatsReset()
+        }
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="Settings">
+            <div className="space-y-4 text-center">
+                <div>
+                    <label className="block mb-2">Change Username</label>
+                    <input
+                        className="text-black px-2 py-1 rounded-xl"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                    />
+                    <button
+                        className="ml-2 bg-amber-700 hover:bg-amber-800 text-white px-3 py-1 rounded-xl"
+                        onClick={handleUsernameChange}
+                    >
+                        Save
+                    </button>
+                    {error && <p className="text-red-500 mt-2">{error}</p>}
+                </div>
+                <div>
+                    <label className="flex items-center justify-center space-x-2">
+                        <input
+                            type="checkbox"
+                            checked={scoreboardVisible}
+                            onChange={(e) => setScoreboardVisible(e.target.checked)}
+                        />
+                        <span>Show Scoreboard</span>
+                    </label>
+                </div>
+                <div>
+                    <label className="flex items-center justify-center space-x-2">
+                        <input
+                            type="checkbox"
+                            checked={controlsVisible}
+                            onChange={(e) => setControlsVisible(e.target.checked)}
+                        />
+                        <span>Show Controls</span>
+                    </label>
+                </div>
+                <div>
+                    <button
+                        className="bg-red-800 hover:bg-red-900 text-white px-3 py-1 rounded-xl"
+                        onClick={handleResetStats}
+                    >
+                        Reset Stats
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    )
+}
+
+export default Settings


### PR DESCRIPTION
## Summary
- implement Settings modal component
- wire up settings in App to toggle scoreboard and controls
- allow username change with profanity and duplicate checks
- add option to reset stats via Supabase

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847a1e661a083259dabaa6b7b08ae82