### PR TITLE
Add sortable leaderboard and settings improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,3 +46,16 @@
 body {
   @apply text-white text-lg leading-relaxed antialiased;
 }
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.fade-out {
+  animation: fadeOut 3s forwards;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ function App() {
   const [username, setUsername] = useState('')
   const [showScoreboard, setShowScoreboard] = useState(true)
   const [showControls, setShowControls] = useState(true)
+  const [settingsOpen, setSettingsOpen] = useState(false)
   const prevGameState = useRef(null)
 
   useEffect(() => {
@@ -131,12 +132,18 @@ function App() {
       <Message gameState={gameState} />
       <PlayerHand hand={playerHand} />
       {showControls && (
-        <Controls onHit={handleHit} onStand={handleStand} gameState={gameState} />
+        <Controls
+          onHit={handleHit}
+          onStand={handleStand}
+          gameState={gameState}
+          disabled={settingsOpen}
+        />
       )}
       <DealerHand hand={dealerHand} gameState={gameState} />
       <Settings
         playerId={playerId}
         onUsernameChange={setUsername}
+        currentUsername={username}
         wins={wins}
         losses={losses}
         streak={streak}
@@ -147,9 +154,11 @@ function App() {
         setShowScoreboard={setShowScoreboard}
         showControls={showControls}
         setShowControls={setShowControls}
+        onOpenChange={setSettingsOpen}
       />
     </div>
   )
 }
 
 export default App
+

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
 // Controls component handles player actions during their turn with visual press feedback
-function Controls({ onHit, onStand, gameState }) {
+function Controls({ onHit, onStand, gameState, disabled = false }) {
     const [hitPressed, setHitPressed] = useState(false);
     const [standPressed, setStandPressed] = useState(false);
 
     useEffect(() => {
+        if (disabled) return;
+
         function handleKeyDown(event) {
             if (gameState !== 'player_turn') return;
 
@@ -21,7 +23,7 @@ function Controls({ onHit, onStand, gameState }) {
 
         window.addEventListener('keydown', handleKeyDown)
         return () => window.removeEventListener('keydown', handleKeyDown)
-    }, [onHit, onStand, gameState]);
+    }, [onHit, onStand, gameState, disabled]);
 
     return (
         <div className="fixed bottom-12 right-12 flex flex-col space-y-2">

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -1,17 +1,19 @@
 import React, { useState, useEffect } from 'react';
+import { FaSort, FaSortUp, FaSortDown } from 'react-icons/fa';
 import Modal from './Modal';
 import { supabase } from '../supabaseClient';
 
 function Leaderboard() {
     const [isOpen, setIsOpen] = useState(false);
     const [players, setPlayers] = useState([]);
+    const [sortColumn, setSortColumn] = useState('win_count');
+    const [sortAsc, setSortAsc] = useState(false);
 
     useEffect(() => {
         const fetchPlayers = async () => {
             const { data, error } = await supabase
                 .from('blackjack_players')
-                .select('username, win_count, loss_count, streak')
-                .order('win_count', { ascending: false });
+                .select('username, win_count, loss_count, streak');
 
             if (error) {
                 console.error('Error fetching leaderboard data:', error);
@@ -23,11 +25,29 @@ function Leaderboard() {
         if (isOpen) fetchPlayers();
     }, [isOpen]);
 
+    const sortedPlayers = [...players].sort((a, b) => {
+        if (sortColumn === 'username') {
+            return sortAsc
+                ? a.username.localeCompare(b.username)
+                : b.username.localeCompare(a.username);
+        }
+        return sortAsc ? a[sortColumn] - b[sortColumn] : b[sortColumn] - a[sortColumn];
+    });
+
+    const handleSort = (column) => {
+        if (sortColumn === column) {
+            setSortAsc((prev) => !prev);
+        } else {
+            setSortColumn(column);
+            setSortAsc(true);
+        }
+    };
+
     return (
         <div>
             <div className="fixed bottom-12 left-12 z-[9999]">
                 <button
-                    className="bg-red-800 hover:bg-red-900 text-white rounded-xl shadow-lg font-semibold transition-all border border-black 
+                    className="bg-red-800 hover:bg-red-900 text-white rounded-xl shadow-lg font-semibold transition-all border border-black
                     px-3 py-1
                     lg:px-4 lg:py-2
                     xl:px-5 xl:py-3
@@ -49,14 +69,62 @@ function Leaderboard() {
                     <table className="w-full text-left text-sm lg:text-base table-auto border-collapse">
                         <thead className="sticky top-0 z-10 bg-white text-black">
                             <tr>
-                                <th className="px-4 py-2 border border-[#4B5563] w-[40%]">Username</th>
-                                <th className="px-4 py-2 border border-[#4B5563] w-[20%]">Wins</th>
-                                <th className="px-4 py-2 border border-[#4B5563] w-[20%]">Losses</th>
-                                <th className="px-4 py-2 border border-[#4B5563] w-[20%]">Streak Record</th>
+                                <th
+                                    className="px-4 py-2 border border-[#4B5563] w-[40%] cursor-pointer select-none"
+                                    onClick={() => handleSort('username')}
+                                >
+                                    <div className="flex items-center space-x-1">
+                                        <span>Username</span>
+                                        {sortColumn === 'username' ? (
+                                            sortAsc ? <FaSortUp /> : <FaSortDown />
+                                        ) : (
+                                            <FaSort />
+                                        )}
+                                    </div>
+                                </th>
+                                <th
+                                    className="px-4 py-2 border border-[#4B5563] w-[20%] cursor-pointer select-none"
+                                    onClick={() => handleSort('win_count')}
+                                >
+                                    <div className="flex items-center space-x-1">
+                                        <span>Wins</span>
+                                        {sortColumn === 'win_count' ? (
+                                            sortAsc ? <FaSortUp /> : <FaSortDown />
+                                        ) : (
+                                            <FaSort />
+                                        )}
+                                    </div>
+                                </th>
+                                <th
+                                    className="px-4 py-2 border border-[#4B5563] w-[20%] cursor-pointer select-none"
+                                    onClick={() => handleSort('loss_count')}
+                                >
+                                    <div className="flex items-center space-x-1">
+                                        <span>Losses</span>
+                                        {sortColumn === 'loss_count' ? (
+                                            sortAsc ? <FaSortUp /> : <FaSortDown />
+                                        ) : (
+                                            <FaSort />
+                                        )}
+                                    </div>
+                                </th>
+                                <th
+                                    className="px-4 py-2 border border-[#4B5563] w-[20%] cursor-pointer select-none"
+                                    onClick={() => handleSort('streak')}
+                                >
+                                    <div className="flex items-center space-x-1">
+                                        <span>Streak Record</span>
+                                        {sortColumn === 'streak' ? (
+                                            sortAsc ? <FaSortUp /> : <FaSortDown />
+                                        ) : (
+                                            <FaSort />
+                                        )}
+                                    </div>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
-                            {players.map((player, index) => (
+                            {sortedPlayers.map((player, index) => (
                                 <tr
                                     key={index}
                                     className="text-[#E5E7EB] even:bg-[#1a1a1a] odd:bg-[#111111] hover:bg-[#272727] transition"

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -6,6 +6,7 @@ import { supabase } from '../supabaseClient'
 export default function Settings({
     playerId,
     onUsernameChange,
+    currentUsername,
     wins,
     losses,
     streak,
@@ -15,7 +16,8 @@ export default function Settings({
     showScoreboard,
     setShowScoreboard,
     showControls,
-    setShowControls
+    setShowControls,
+    onOpenChange = () => {}
 }) {
     const [open, setOpen] = useState(false)
     const [username, setUsername] = useState('')
@@ -45,14 +47,17 @@ export default function Settings({
     }, [statsError, statsSuccess]);
 
     useEffect(() => {
-        if (!open) {
+        if (open) {
+            setUsername(currentUsername)
+        } else {
             setUsername('')
             setUsernameError('')
             setUsernameSuccess('')
             setStatsError('')
             setStatsSuccess('')
         }
-    }, [open])
+        onOpenChange(open)
+    }, [open, currentUsername, onOpenChange])
 
     async function handleUsernameChange() {
         setUsernameError('')
@@ -137,12 +142,12 @@ export default function Settings({
                         </button>
                         <div className="mt-4 min-h-[1.8rem]">
                             <p
-                                className={`text-red-500 transition-opacity duration-10000 ${usernameError ? 'opacity-0' : 'opacity-100'}`}
+                                className={`text-red-500 ${usernameError ? 'fade-out' : 'opacity-0'}`}
                             >
                                 {usernameError}
                             </p>
                             <p
-                                className={`text-green-500 transition-opacity duration-10000 ${usernameSuccess ? 'opacity-0' : 'opacity-100'}`}
+                                className={`text-green-500 ${usernameSuccess ? 'fade-out' : 'opacity-0'}`}
                             >
                                 {usernameSuccess}
                             </p>
@@ -166,21 +171,21 @@ export default function Settings({
                             <span>Show Controls</span>
                         </div>
                     </div>
-                    <div className="space-y-2">
+                    <div className="flex items-center space-x-4">
                         <button
                             className="w-2/5 bg-red-800 hover:bg-red-900 text-white px-3 py-1 rounded"
                             onClick={handleResetStats}
                         >
                             Reset Stats
                         </button>
-                        <div className="min-h-[1.8rem]">
+                        <div className="min-h-[1.8rem] w-40">
                             <p
-                                className={`text-red-500 transition-opacity duration-10000 ${statsError ? 'opacity-0' : 'opacity-100'}`}
+                                className={`text-red-500 ${statsError ? 'fade-out' : 'opacity-0'}`}
                             >
                                 {statsError}
                             </p>
                             <p
-                                className={`text-green-500 transition-opacity duration-10000 ${statsSuccess ? 'opacity-0' : 'opacity-100'}`}
+                                className={`text-green-500 ${statsSuccess ? 'fade-out' : 'opacity-0'}`}
                             >
                                 {statsSuccess}
                             </p>
@@ -191,3 +196,4 @@ export default function Settings({
         </div>
     )
 }
+


### PR DESCRIPTION
## Summary
- allow sorting leaderboard by clicking column headers
- show sorting icons on leaderboard headers
- disable key controls when settings window is open
- default username displayed in settings and layout tweaks
- fade out error messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847c469e8848325aa2f33c910756e39