### PR TITLE
Add auto tutorial launch and win streak tracking

### DIFF
--- a/src/components/Tutorial.jsx
+++ b/src/components/Tutorial.jsx
@@ -1,8 +1,14 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Modal from './Modal';
 
-function Tutorial() {
-    const [isOpen, setIsOpen] = useState(false);
+function Tutorial({ initialOpen = false }) {
+    const [isOpen, setIsOpen] = useState(initialOpen);
+
+    useEffect(() => {
+        if (initialOpen) {
+            setIsOpen(true);
+        }
+    }, [initialOpen]);
 
     return (
         <div>

--- a/src/playerManager.js
+++ b/src/playerManager.js
@@ -8,7 +8,6 @@ export async function getOrCreatePlayer() {
     if (playerId) {
         console.log('Player found in local storage:', playerId)
 
-        // Fetch full player info from Supabase
         const { data, error } = await supabase
             .from('blackjack_players')
             .select()
@@ -21,7 +20,7 @@ export async function getOrCreatePlayer() {
         }
 
         console.log('Loaded player data:', data)
-        return data
+        return { player: data, isNew: false }
     }
 
     const username = 'Player_' + Math.floor(Math.random() * 100000)
@@ -40,5 +39,5 @@ export async function getOrCreatePlayer() {
     localStorage.setItem(LOCAL_STORAGE_KEY, player.id)
     console.log('New player created:', player)
 
-    return player
+    return { player, isNew: true }
 }


### PR DESCRIPTION
## Summary
- open tutorial automatically when a new player account is created
- track current win streak and update record in Supabase

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847d07030b08325865bbf4eaa5115b7