### PR TITLE
Keep keyboard shortcuts when controls are hidden

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,14 +41,33 @@ function App() {
         setAutoOpenTutorial(true)
       }
 
-      const { deck, playerHand, dealerHand, result } = startGame();
-      setDeck(deck);
-      setPlayerHand(playerHand);
-      setDealerHand(dealerHand);
-      setGameState(result ?? 'player_turn');
+      const saved = localStorage.getItem('game_state')
+      if (saved) {
+        try {
+          const state = JSON.parse(saved)
+          setDeck(state.deck || [])
+          setPlayerHand(state.playerHand || [])
+          setDealerHand(state.dealerHand || [])
+          setGameState(state.gameState || 'player_turn')
+          return
+        } catch (e) {
+          console.error('Failed to parse saved game state', e)
+        }
+      }
+
+      const { deck, playerHand, dealerHand, result } = startGame()
+      setDeck(deck)
+      setPlayerHand(playerHand)
+      setDealerHand(dealerHand)
+      setGameState(result ?? 'player_turn')
     }
     init()
   }, [])
+
+  useEffect(() => {
+    const state = { deck, playerHand, dealerHand, gameState }
+    localStorage.setItem('game_state', JSON.stringify(state))
+  }, [deck, playerHand, dealerHand, gameState])
 
   const handleHit = () => {
     const { deck: newDeck, playerHand: newPlayerHand, result } = hit(deck, playerHand);
@@ -146,14 +165,13 @@ function App() {
       )}
       <Message gameState={gameState} />
       <PlayerHand hand={playerHand} />
-      {showControls && (
-        <Controls
-          onHit={handleHit}
-          onStand={handleStand}
-          gameState={gameState}
-          disabled={settingsOpen}
-        />
-      )}
+      <Controls
+        onHit={handleHit}
+        onStand={handleStand}
+        gameState={gameState}
+        disabled={settingsOpen}
+        visible={showControls}
+      />
       <DealerHand hand={dealerHand} gameState={gameState} />
       <Settings
         playerId={playerId}

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 // Controls component handles player actions during their turn with visual press feedback
-function Controls({ onHit, onStand, gameState, disabled = false }) {
+function Controls({ onHit, onStand, gameState, disabled = false, visible = true }) {
     const [hitPressed, setHitPressed] = useState(false);
     const [standPressed, setStandPressed] = useState(false);
 
@@ -26,7 +26,7 @@ function Controls({ onHit, onStand, gameState, disabled = false }) {
     }, [onHit, onStand, gameState, disabled]);
 
     return (
-        <div className="fixed bottom-12 right-12 flex flex-col space-y-2">
+        <div className={`fixed bottom-12 right-12 flex flex-col space-y-2 ${!visible ? 'hidden' : ''}`}>
             <button
                 onClick={() => {
                     setHitPressed(true);


### PR DESCRIPTION
## Summary
- keep controls mounted and hide using CSS so keyboard listeners remain active
- persist current game state to localStorage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847d863ccb883259048717cf9cc49e0