### PR TITLE
Add audio loop and sound effect toggles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,8 +28,38 @@ function App() {
   const [username, setUsername] = useState('')
   const [showScoreboard, setShowScoreboard] = useState(true)
   const [showControls, setShowControls] = useState(true)
+  const [playAmbiance, setPlayAmbiance] = useState(true)
+  const [playSfx, setPlaySfx] = useState(true)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const prevGameState = useRef(null)
+  const ambianceRef = useRef(null)
+
+  useEffect(() => {
+    ambianceRef.current = new Audio('/audio/casino_ambiance.wav')
+    ambianceRef.current.loop = true
+    if (playAmbiance) {
+      ambianceRef.current.play()
+    }
+    return () => {
+      ambianceRef.current.pause()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!ambianceRef.current) return
+    if (playAmbiance) {
+      ambianceRef.current.play()
+    } else {
+      ambianceRef.current.pause()
+    }
+  }, [playAmbiance])
+
+  const playCardSound = () => {
+    if (playSfx) {
+      const sfx = new Audio('/audio/card_draw.mp3')
+      sfx.play()
+    }
+  }
 
   useEffect(() => {
     async function init() {
@@ -70,6 +100,7 @@ function App() {
     const { deck: newDeck, playerHand: newPlayerHand, result } = hit(deck, playerHand);
     setDeck(newDeck);
     setPlayerHand(newPlayerHand);
+    playCardSound()
 
     if (result) {
       setGameState(result);
@@ -101,12 +132,16 @@ function App() {
 
   useEffect(() => {
     if (gameState === 'dealer_turn') {
-      const { deck: newDeck, dealerHand: newDealerHand, result } = dealerTurn(deck, dealerHand, playerHand);
-      setDeck(newDeck);
-      setDealerHand(newDealerHand);
-      setGameState(result);
+      const { deck: newDeck, dealerHand: newDealerHand, result } = dealerTurn(deck, dealerHand, playerHand)
+      const draws = newDealerHand.length - dealerHand.length
+      setDeck(newDeck)
+      setDealerHand(newDealerHand)
+      setGameState(result)
+      for (let i = 0; i < draws; i += 1) {
+        playCardSound()
+      }
     }
-  }, [gameState, deck, dealerHand, playerHand]);
+  }, [gameState, deck, dealerHand, playerHand, playSfx]);
 
   useEffect(() => {
     async function updateStats() {
@@ -195,6 +230,10 @@ function App() {
         setShowScoreboard={setShowScoreboard}
         showControls={showControls}
         setShowControls={setShowControls}
+        playAmbiance={playAmbiance}
+        setPlayAmbiance={setPlayAmbiance}
+        playSfx={playSfx}
+        setPlaySfx={setPlaySfx}
         onOpenChange={setSettingsOpen}
       />
     </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -17,6 +17,10 @@ export default function Settings({
     setShowScoreboard,
     showControls,
     setShowControls,
+    playAmbiance,
+    setPlayAmbiance,
+    playSfx,
+    setPlaySfx,
     onOpenChange = () => { }
 }) {
     const [open, setOpen] = useState(false)
@@ -169,6 +173,24 @@ export default function Settings({
                                 onChange={(e) => setShowControls(e.target.checked)}
                             />
                             <span>Show Controls</span>
+                        </div>
+                    </div>
+                    <div className="flex space-x-16">
+                        <div className="flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                checked={playAmbiance}
+                                onChange={(e) => setPlayAmbiance(e.target.checked)}
+                            />
+                            <span>Ambiance Music</span>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                checked={playSfx}
+                                onChange={(e) => setPlaySfx(e.target.checked)}
+                            />
+                            <span>Sound Effects</span>
                         </div>
                     </div>
                     <div className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- implement playing casino ambiance on loop
- play card draw sound effect whenever cards are drawn
- allow toggling ambiance music and sound effects in settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68487b133050832589906cbdcf8f4485