### PR TITLE
Update CI actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## What changed

- Updates `actions/checkout` from v4 to the current v7 major release.
- Updates `actions/setup-node` from v4 to the current v7 major release.

## Why

The first post-merge CI run passed but emitted a GitHub-hosted runner annotation because the v4 actions target deprecated Node 20. The current official v7 releases use the maintained action runtime and remove that warning.

## Validation

- `npm run check`: lint pass, 10/10 tests pass, production build pass
- `npm audit --audit-level=high`: 0 vulnerabilities
- Official v7 releases confirmed in `actions/checkout` and `actions/setup-node`